### PR TITLE
Fix: discover hook paths

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -14,6 +14,11 @@ Release Notes
         :tags: UI
 
         Application crash on Windows 8.1.
+        
+    .. change: fixed
+        :tags: API
+        
+        Assure all plugin paths are unique.
 
 .. release:: 2.0.1
     :date: 2022-09-01

--- a/source/ftrack_connect/ui/application.py
+++ b/source/ftrack_connect/ui/application.py
@@ -746,13 +746,15 @@ class Application(QtWidgets.QMainWindow):
                 self._gatherPluginHooks(os.path.expandvars(connectPluginPath))
             )
 
+        plugin_paths = list(set(plugin_paths))
+
         self.logger.info(
             u'Connect plugin hooks directories: {0}'.format(
                 ', '.join(plugin_paths)
             )
         )
 
-        return list(plugin_paths)
+        return plugin_paths
 
     def _gatherPluginHooks(self, path):
         '''Return plugin hooks from *path*.'''

--- a/source/ftrack_connect/ui/application.py
+++ b/source/ftrack_connect/ui/application.py
@@ -736,7 +736,7 @@ class Application(QtWidgets.QMainWindow):
         for apiPluginPath in os.environ.get(
             'FTRACK_EVENT_PLUGIN_PATH', ''
         ).split(os.pathsep):
-            if apiPluginPath not in plugin_paths:
+            if apiPluginPath and apiPluginPath not in plugin_paths:
                 plugin_paths.append(os.path.expandvars(apiPluginPath))
 
         for connectPluginPath in os.environ.get(


### PR DESCRIPTION
the pr has two minor fixes  
1. [stop adding empty strings to the plugin paths](https://github.com/blockinhead/ftrack-connect/commit/624d6f7d3035ccbee6f460bbdd017df1af5e477a)
2. [make sure plugin paths are unique](https://github.com/blockinhead/ftrack-connect/commit/f07c453bbfd7ace8449eed93c6769adcf8b7917f). definitely one does not want to load the same plugin two times. the easiest way to do so is to set ```FTRACK_CONNECT_PLUGIN_PATH``` to ```defaultPluginDirectory```. but there is another possibilitie of misuse with ```FTRACK_EVENT_PLUGIN_PATH```.  