### PR TITLE
Fix:  for darkdetect: digit check and fallback

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -8,6 +8,12 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+        :tags: UI
+
+        Application crash on Windows 8.1.
 
 .. release:: 2.0.1
     :date: 2022-09-01

--- a/source/ftrack_connect/ui/application.py
+++ b/source/ftrack_connect/ui/application.py
@@ -288,11 +288,18 @@ class Application(QtWidgets.QMainWindow):
         if sys.platform == "darwin":
             from darkdetect import _mac_detect as stylemodule
 
-        elif sys.platform == "win32" and int(platform.release()) >= 10:
+        elif (
+                sys.platform == "win32"
+                and platform.release().isdigit()  # Windows 8.1 would result in '8.1' str
+                and int(platform.release()) >= 10
+        ):
             from darkdetect import _windows_detect as stylemodule
 
         elif sys.platform == "linux":
             from darkdetect import _linux_detect as stylemodule
+
+        else:
+            from darkdetect import _dummy as stylemodule
 
         current_theme = stylemodule.theme()
         if not current_theme:


### PR DESCRIPTION
Hi.

A small fix for Windows 8.1. Connect crashes otherwise on 8.1 (trying to run `int()` on str `'8.1'`).

Although Windows 8.1 support ends in near future (Jan 2023), I think it would be better to fix this.

Also, there wasn't a dummy fallback, could cause uninitiated variable access to `stylemodule`.

![Screenshot_20221228_130852](https://user-images.githubusercontent.com/9142081/209802292-66631297-f6b5-4f58-b02c-8130838f6f35.png)
