### PR TITLE
feat: Backlog/install plugins on launch

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -10,6 +10,11 @@ Release Notes
 
 .. release:: Upcoming
 
+    .. change:: changed
+        :tags: Plugins
+
+        Install all plugins on first launch.
+
     .. change:: fixed
         :tags: UI
 

--- a/source/ftrack_connect/__init__.py
+++ b/source/ftrack_connect/__init__.py
@@ -14,7 +14,9 @@ _resource = {"loaded": False}
 
 def load_icons(font_folder):
     font_folder = os.path.abspath(font_folder)
-    logger.info(f'loading ftrack icon fonts from {font_folder} : resource already loaded {_resource["loaded"]}')
+    logger.info(
+        f'loading ftrack icon fonts from {font_folder} : resource already loaded {_resource["loaded"]}'
+    )
     if not _resource['loaded']:
         qta.load_font(
             'ftrack',
@@ -22,4 +24,4 @@ def load_icons(font_folder):
             'ftrack-icon-charmap.json',
             directory=font_folder,
         )
-        _resource['loaded']=True
+        _resource['loaded'] = True

--- a/source/ftrack_connect/ui/application.py
+++ b/source/ftrack_connect/ui/application.py
@@ -115,31 +115,35 @@ class WelcomePlugin(ConnectWidget):
     plugins_installed = QtCore.Signal()
     installing = QtCore.Signal()
     # local variables for finding and installing plugin manager.
-    install_path = appdirs.user_data_dir(
-        'ftrack-connect-plugins', 'ftrack'
-    )
+    install_path = appdirs.user_data_dir('ftrack-connect-plugins', 'ftrack')
 
     json_config_url = os.environ.get(
         'FTRACK_CONNECT_JSON_PLUGINS_URL',
-        'https://download.ftrack.com/ftrack-connect/plugins.json'
+        'https://download.ftrack.com/ftrack-connect/plugins.json',
     )
 
     def download_plugins(self, source_paths):
         '''Download plugins from provided *source_paths* item.'''
         temp_paths = []
-        self.overlay.setMessage("Downloaded 0/{} plugins.".format(len(source_paths)))
+        self.overlay.setMessage(
+            "Downloaded 0/{} plugins.".format(len(source_paths))
+        )
         i = 1
         for source_path in source_paths:
             zip_name = os.path.basename(source_path)
             save_path = tempfile.gettempdir()
             temp_path = os.path.join(save_path, zip_name)
-            logging.debug('Downloading {} to {}'.format(source_path, temp_path))
+            logging.debug(
+                'Downloading {} to {}'.format(source_path, temp_path)
+            )
 
             with urllib.request.urlopen(source_path) as dl_file:
                 with open(temp_path, 'wb') as out_file:
                     out_file.write(dl_file.read())
             temp_paths.append(temp_path)
-            self.overlay.setMessage("Downloaded {}/{} plugins.".format(i, len(source_paths)))
+            self.overlay.setMessage(
+                "Downloaded {}/{} plugins.".format(i, len(source_paths))
+            )
             i += 1
         return temp_paths
 
@@ -151,7 +155,13 @@ class WelcomePlugin(ConnectWidget):
             plugins_url = []
             if plugin_names:
                 for plugin_name in plugin_names:
-                    plugins_url.extend([plugin_url for plugin_url in data.get('integrations') if plugin_name in plugin_url])
+                    plugins_url.extend(
+                        [
+                            plugin_url
+                            for plugin_url in data.get('integrations')
+                            if plugin_name in plugin_url
+                        ]
+                    )
             else:
                 plugins_url = data.get('integrations')
 
@@ -166,19 +176,26 @@ class WelcomePlugin(ConnectWidget):
         '''Install provided *plugin_names*. If no plugin_names install all them'''
         self.installing.emit()
         plugins_path = self.discover_plugins(plugin_names)
-        self.overlay.setMessage("Discovered {} plugins.".format(len(plugins_path)))
+        self.overlay.setMessage(
+            "Discovered {} plugins.".format(len(plugins_path))
+        )
         source_paths = self.download_plugins(plugins_path)
-        self.overlay.setMessage("Installed 0/{} plugins.".format(len(source_paths)))
+        self.overlay.setMessage(
+            "Installed 0/{} plugins.".format(len(source_paths))
+        )
         i = 1
         for source_path in source_paths:
-
             plugin_name = os.path.basename(source_path).split('.zip')[0]
             destination_path = os.path.join(self.install_path, plugin_name)
-            logging.debug('Installing {} to {}'.format(source_path, destination_path))
+            logging.debug(
+                'Installing {} to {}'.format(source_path, destination_path)
+            )
 
             with zipfile.ZipFile(source_path, 'r') as zip_ref:
                 zip_ref.extractall(destination_path)
-            self.overlay.setMessage("Installed {}/{} plugins.".format(i, len(source_paths)))
+            self.overlay.setMessage(
+                "Installed {}/{} plugins.".format(i, len(source_paths))
+            )
             i += 1
 
         self.plugins_installed.emit()
@@ -198,17 +215,24 @@ class WelcomePlugin(ConnectWidget):
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(30, 0, 30, 0)
         self.setLayout(layout)
-        spacer = QtWidgets.QSpacerItem(0, 70, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacer = QtWidgets.QSpacerItem(
+            0,
+            70,
+            QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.Expanding,
+        )
         layout.addItem(spacer)
 
         icon_label = QtWidgets.QLabel()
-        icon = qta.icon("ph.rocket", color='#FFDD86', rotated=45, scale_factor=0.7)
-        icon_label.setPixmap(icon.pixmap(icon.actualSize(QtCore.QSize(180, 180))))
+        icon = qta.icon(
+            "ph.rocket", color='#FFDD86', rotated=45, scale_factor=0.7
+        )
+        icon_label.setPixmap(
+            icon.pixmap(icon.actualSize(QtCore.QSize(180, 180)))
+        )
         icon_label.setAlignment(QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
 
-        label_title = QtWidgets.QLabel(
-            "<H1>Let's get started!</H1>"
-        )
+        label_title = QtWidgets.QLabel("<H1>Let's get started!</H1>")
         label_title.setAlignment(QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
 
         label_text = QtWidgets.QLabel(
@@ -224,9 +248,7 @@ class WelcomePlugin(ConnectWidget):
         )
         self.install_button.setObjectName('primary')
 
-        self.restart_button = QtWidgets.QPushButton(
-            'Restart Now'
-        )
+        self.restart_button = QtWidgets.QPushButton('Restart Now')
 
         self.restart_button.setObjectName('primary')
         self.restart_button.setVisible(False)
@@ -234,17 +256,30 @@ class WelcomePlugin(ConnectWidget):
         label_text.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
         label_text.setWordWrap(True)
 
-        layout.addWidget(label_title, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
-        layout.addWidget(icon_label, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
-        layout.addWidget(label_text, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
+        layout.addWidget(
+            label_title, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
+        )
+        layout.addWidget(
+            icon_label, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
+        )
+        layout.addWidget(
+            label_text, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
+        )
         layout.addWidget(self.install_button)
         layout.addWidget(self.install_plug_man_button)
         layout.addWidget(self.restart_button)
 
-        spacer = QtWidgets.QSpacerItem(0, 300, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacer = QtWidgets.QSpacerItem(
+            0,
+            300,
+            QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.Expanding,
+        )
         layout.addItem(spacer)
         self.install_button.clicked.connect(self.install_plugins)
-        self.install_plug_man_button.clicked.connect(partial(self.install_plugins, plugin_names=['plugin_manager']))
+        self.install_plug_man_button.clicked.connect(
+            partial(self.install_plugins, plugin_names=['plugin_manager'])
+        )
         self.plugins_installed.connect(self._on_plugins_installed)
         self.installing.connect(self._on_plugins_installing)
         self.restart_button.clicked.connect(self.requestConnectRestart.emit)
@@ -324,9 +359,9 @@ class Application(QtWidgets.QMainWindow):
             from darkdetect import _mac_detect as stylemodule
 
         elif (
-                sys.platform == "win32"
-                and platform.release().isdigit()  # Windows 8.1 would result in '8.1' str
-                and int(platform.release()) >= 10
+            sys.platform == "win32"
+            and platform.release().isdigit()  # Windows 8.1 would result in '8.1' str
+            and int(platform.release()) >= 10
         ):
             from darkdetect import _windows_detect as stylemodule
 
@@ -409,7 +444,6 @@ class Application(QtWidgets.QMainWindow):
         self.login()
 
     def _post_login_settings(self):
-
         if self.tray:
             self.tray.show()
 
@@ -899,14 +933,17 @@ class Application(QtWidgets.QMainWindow):
                 self.addPlugin(widget_plugin)
         else:
             for ResponsePlugin in responses:
-
                 try:
-                    load_icons(os.path.join(os.path.dirname(__file__),  '..', 'fonts'))
+                    load_icons(
+                        os.path.join(os.path.dirname(__file__), '..', 'fonts')
+                    )
                     widget_plugin = ResponsePlugin(self.session)
 
                 except Exception:
                     self.logger.exception(
-                        msg='Error while loading plugin : {}'.format(widget_plugin)
+                        msg='Error while loading plugin : {}'.format(
+                            widget_plugin
+                        )
                     )
                     continue
 
@@ -1008,9 +1045,7 @@ class Application(QtWidgets.QMainWindow):
         plugin.requestApplicationClose.connect(
             self._onWidgetRequestApplicationClose
         )
-        plugin.requestConnectRestart.connect(
-            self.restart
-        )
+        plugin.requestConnectRestart.connect(self.restart)
 
     def removePlugin(self, plugin):
         '''Remove plugin registered with *identifier*.

--- a/source/ftrack_connect/ui/application.py
+++ b/source/ftrack_connect/ui/application.py
@@ -278,7 +278,7 @@ class WelcomePlugin(ConnectWidget):
         layout.addItem(spacer)
         self.install_button.clicked.connect(self.install_plugins)
         self.install_plug_man_button.clicked.connect(
-            partial(self.install_plugins, plugin_names=['plugin_manager'])
+            partial(self.install_plugins, plugin_names=['plugin-manager'])
         )
         self.plugins_installed.connect(self._on_plugins_installed)
         self.installing.connect(self._on_plugins_installing)

--- a/source/ftrack_connect/ui/widget/about.py
+++ b/source/ftrack_connect/ui/widget/about.py
@@ -22,9 +22,7 @@ import ftrack_connect.util
 class AboutDialog(QtWidgets.QDialog):
     '''About widget.'''
 
-    def __init__(
-        self, parent, icon=':ftrack/connect/logo/dark2x'
-    ):
+    def __init__(self, parent, icon=':ftrack/connect/logo/dark2x'):
         super(AboutDialog, self).__init__(parent)
         self.setWindowTitle('About connect')
         layout = QtWidgets.QVBoxLayout()

--- a/source/ftrack_connect/ui/widget/configure_scenario.py
+++ b/source/ftrack_connect/ui/widget/configure_scenario.py
@@ -24,7 +24,9 @@ class ConfigureScenario(QtWidgets.QWidget):
     def __init__(self, session):
         '''Instantiate the configure scenario widget.'''
         super(ConfigureScenario, self).__init__()
-        icons_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'fonts'))
+        icons_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..', '..', 'fonts')
+        )
         load_icons(icons_path)
 
         # Check if user has permissions to configure scenario.

--- a/source/ftrack_connect/ui/widget/data_drop_zone.py
+++ b/source/ftrack_connect/ui/widget/data_drop_zone.py
@@ -147,8 +147,10 @@ class DataDropZone(QtWidgets.QFrame):
                 self._setDropZoneState('invalid')
 
                 if raise_message:
-                    message = u'Invalid file: "{0}" is not a valid file.'.format(
-                        localPath
+                    message = (
+                        u'Invalid file: "{0}" is not a valid file.'.format(
+                            localPath
+                        )
                     )
                     if os.path.isdir(localPath):
                         message = (
@@ -157,7 +159,9 @@ class DataDropZone(QtWidgets.QFrame):
                             'later release of ftrack connect.'
                         )
 
-                    QtWidgets.QMessageBox.warning(self, 'Invalid file', message)
+                    QtWidgets.QMessageBox.warning(
+                        self, 'Invalid file', message
+                    )
 
                     self._setDropZoneState()
 

--- a/source/ftrack_connect/ui/widget/entity_selector.py
+++ b/source/ftrack_connect/ui/widget/entity_selector.py
@@ -20,7 +20,9 @@ class ContextList(QtWidgets.QComboBox):
         return self.minimumSizeHint()
 
     def minimumSizeHint(self):
-        return QtCore.QSize(50, QtWidgets.QComboBox.minimumSizeHint(self).height())
+        return QtCore.QSize(
+            50, QtWidgets.QComboBox.minimumSizeHint(self).height()
+        )
 
 
 class EntitySelector(QtWidgets.QStackedWidget):

--- a/source/ftrack_connect/ui/widget/list.py
+++ b/source/ftrack_connect/ui/widget/list.py
@@ -58,7 +58,6 @@ class List(QtWidgets.QTableWidget):
         oldRow = self.indexOfWidget(widget)
 
         if oldRow:
-
             self.insertRow(newRow)
 
             # Collect the oldRow after insert to make sure we move the correct

--- a/source/ftrack_connect/ui/widget/login.py
+++ b/source/ftrack_connect/ui/widget/login.py
@@ -37,9 +37,7 @@ class Login(QtWidgets.QWidget):
 
         logo = QtWidgets.QLabel()
 
-        logoPixmap = QtGui.QPixmap(
-            ':ftrack/connect/logo/{}2x'.format(theme)
-        )
+        logoPixmap = QtGui.QPixmap(':ftrack/connect/logo/{}2x'.format(theme))
 
         logo.setPixmap(
             logoPixmap.scaled(
@@ -86,7 +84,6 @@ class Login(QtWidgets.QWidget):
         label.setAlignment(QtCore.Qt.AlignCenter)
         label.setWordWrap(True)
 
-
         # Min height is required due to issue when word wrap is True and window
         # being resized which cases text to dissapear.
         label.setMinimumHeight(50)
@@ -124,8 +121,6 @@ class Login(QtWidgets.QWidget):
             self.untoggle_api_label, alignment=QtCore.Qt.AlignCenter
         )
         layout.addSpacing(20)
-
-
 
     def on_set_error(self, error):
         '''Set the error text and disable the login widget.'''

--- a/source/ftrack_connect/ui/widget/overlay.py
+++ b/source/ftrack_connect/ui/widget/overlay.py
@@ -133,7 +133,7 @@ class BlockingOverlay(Overlay):
         parent,
         message='Processing',
         icon=':ftrack/titlebar/logo',
-        icon_size = 120
+        icon_size=120,
     ):
         '''Initialise with *parent*.
 
@@ -147,7 +147,9 @@ class BlockingOverlay(Overlay):
 
         self.content = QtWidgets.QFrame()
         self.content.setObjectName('content')
-        layout.addWidget(self.content, alignment=QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
+        layout.addWidget(
+            self.content, alignment=QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
+        )
 
         self.contentLayout = QtWidgets.QVBoxLayout()
         self.contentLayout.setContentsMargins(0, 0, 0, 0)
@@ -156,19 +158,26 @@ class BlockingOverlay(Overlay):
         self.icon = QtWidgets.QLabel()
 
         if not isinstance(icon, QtGui.QIcon):
-            pixmap = QtGui.QPixmap(icon).scaled(self.icon_size, self.icon_size, QtCore.Qt.KeepAspectRatio)
+            pixmap = QtGui.QPixmap(icon).scaled(
+                self.icon_size, self.icon_size, QtCore.Qt.KeepAspectRatio
+            )
         else:
-            pixmap = icon.pixmap(icon.actualSize(QtCore.QSize(self.icon_size, self.icon_size)))
+            pixmap = icon.pixmap(
+                icon.actualSize(QtCore.QSize(self.icon_size, self.icon_size))
+            )
 
         self.icon.setPixmap(pixmap)
         self.icon.setAlignment(QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop)
 
         self.contentLayout.insertWidget(
-            1, self.icon, alignment=QtCore.Qt.AlignCenter)
+            1, self.icon, alignment=QtCore.Qt.AlignCenter
+        )
 
         self.messageLabel = QtWidgets.QLabel()
         self.messageLabel.setWordWrap(True)
-        self.messageLabel.setAlignment(QtCore.Qt.AlignCenter | QtCore.Qt.AlignBottom)
+        self.messageLabel.setAlignment(
+            QtCore.Qt.AlignCenter | QtCore.Qt.AlignBottom
+        )
 
         self.contentLayout.addSpacing(30)
 

--- a/source/ftrack_connect/ui/widget/widget_list.py
+++ b/source/ftrack_connect/ui/widget/widget_list.py
@@ -11,7 +11,6 @@ class WidgetList(QtWidgets.QWidget):
         layout.addWidget(self.tablewidget)
 
     def add_plugins(self, plugins):
-
         for plugin_name, plugin_object in plugins.items():
             new_item = QtWidgets.QListWidgetItem(plugin_name)
             new_item.setData(QtCore.Qt.UserRole, plugin_object)

--- a/test/interactive/action_item.py
+++ b/test/interactive/action_item.py
@@ -61,5 +61,4 @@ class WidgetHarness(Harness):
 
 
 if __name__ == '__main__':
-
     raise SystemExit(WidgetHarness().run())

--- a/test/interactive/asset_options.py
+++ b/test/interactive/asset_options.py
@@ -51,5 +51,4 @@ class WidgetHarness(Harness):
 
 
 if __name__ == '__main__':
-
     raise SystemExit(WidgetHarness().run())


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-https://app.clickup.com/t/865bzd06j
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [x ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ x] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
There is now 2 buttons on during Connect first launch. Default one installs all plugins, secondary one installs only plugin manager.
## Test
<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
