### PR TITLE
feat: Backlog/enable framework standalone

### DIFF
--- a/source/ftrack_connect/__main__.py
+++ b/source/ftrack_connect/__main__.py
@@ -11,7 +11,7 @@ import pkg_resources
 import importlib
 
 def main_connect(arguments=None):
-    '''ftrack connect.'''
+    '''Launch ftrack connect.'''
 
     bindings = ['PySide2']
     os.environ.setdefault('QT_PREFERRED_BINDING', os.pathsep.join(bindings))
@@ -152,15 +152,17 @@ def main_connect(arguments=None):
     return application.exec_()
 
 def main(arguments=None):
-
+    '''Main app entry point.'''
+    # Pre-parse arguments to check if we should run a framework standalone process
     framework_standalone_module = None
-    for index,arg in enumerate(sys.argv):
+    for index, arg in enumerate(sys.argv):
         if arg == '--run-framework-standalone':
-            run_framework_standalone = True
+            # (Unoffical feature) Run framework standalone process using Connect Python interpreter
             framework_standalone_module = sys.argv[index+1]
             break
 
     if framework_standalone_module:
+        # Execute the framework standalone module, expected to be available in the PYTHONPATH
         importlib.import_module(framework_standalone_module, package=None)
     else:
         return main_connect(arguments)

--- a/source/ftrack_connect/__main__.py
+++ b/source/ftrack_connect/__main__.py
@@ -8,38 +8,36 @@ import logging
 import signal
 import os
 import pkg_resources
-import qtawesome
+import importlib
 
-bindings = ['PySide2']
-os.environ.setdefault('QT_PREFERRED_BINDING', os.pathsep.join(bindings))
-
-from ftrack_connect.qt import QtWidgets, QtCore
-
-from ftrack_connect import load_icons
-import ftrack_connect.config
-import ftrack_connect.singleton
-
-# Hooks use the ftrack event system. Set the FTRACK_EVENT_PLUGIN_PATH
-# to pick up the default hooks if it has not already been set.
-try:
-    os.environ.setdefault(
-        'FTRACK_EVENT_PLUGIN_PATH',
-        pkg_resources.resource_filename(
-            pkg_resources.Requirement.parse('ftrack-connect'),
-            'ftrack_connect_resource/hook',
-        ),
-    )
-except pkg_resources.DistributionNotFound:
-    # If part of a frozen package then distribution might not be found.
-    pass
-
-
-import ftrack_connect.ui.application
-import ftrack_connect.ui.theme
-
-
-def main(arguments=None):
+def main_connect(arguments=None):
     '''ftrack connect.'''
+
+    bindings = ['PySide2']
+    os.environ.setdefault('QT_PREFERRED_BINDING', os.pathsep.join(bindings))
+
+    from ftrack_connect.qt import QtWidgets, QtCore
+
+    from ftrack_connect import load_icons
+    import ftrack_connect.config
+    import ftrack_connect.singleton
+
+    # Hooks use the ftrack event system. Set the FTRACK_EVENT_PLUGIN_PATH
+    # to pick up the default hooks if it has not already been set.
+    try:
+        os.environ.setdefault(
+            'FTRACK_EVENT_PLUGIN_PATH',
+            pkg_resources.resource_filename(
+                pkg_resources.Requirement.parse('ftrack-connect'),
+                'ftrack_connect_resource/hook',
+            ),
+        )
+    except pkg_resources.DistributionNotFound:
+        # If part of a frozen package then distribution might not be found.
+        pass
+
+    import ftrack_connect.ui.application
+    import ftrack_connect.ui.theme
 
     parser = argparse.ArgumentParser(prog='ftrack-connect')
 
@@ -153,6 +151,19 @@ def main(arguments=None):
 
     return application.exec_()
 
+def main(arguments=None):
+
+    framework_standalone_module = None
+    for index,arg in enumerate(sys.argv):
+        if arg == '--run-framework-standalone':
+            run_framework_standalone = True
+            framework_standalone_module = sys.argv[index+1]
+            break
+
+    if framework_standalone_module:
+        importlib.import_module(framework_standalone_module, package=None)
+    else:
+        return main_connect(arguments)
 
 if __name__ == '__main__':
     raise SystemExit(main())


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-865c05p9y

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

Tested on Mac OS X Monterrey (Intel): **OK**

## Changes

Enable Connect to act as the Python interpreter enabling framework to run in standalone mode.

## Test

- Run Connect without or with standard command line arguments, should work as expected.
- Run with --run-framework-standalone <module> and it should try to import and execute the module supplied as argument.
