### PR TITLE
fix: Limit packaging to prevent crashes on unexpected content in Connect plugin folder

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -8,6 +8,15 @@
 Release Notes
 *************
 
+.. release:: 2.1.1
+    :date: 2023-04-27
+
+    .. change:: fix
+        :tags: Plugins
+
+        Limit packaging to prevent crashes on unexpected content in Connect plugin folder.
+
+
 .. release:: 2.1.0
     :date: 2023-04-05
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ setuptools>=45.0.0
 qtawesome
 wheel
 darkdetect
+packaging<22


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-865c7ekpy
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes

Limit packaging to prevent crashes on unexpected content in Connect plugin folder

## Test

* Create a dummy folder in plugin folder, like "some-dummy-folder"
* Plugin manager should not crash.

