### PR TITLE
feat: Add data.host to target the machine where the action is registered from.

### DIFF
--- a/resource/hook/open_component_directory.py
+++ b/resource/hook/open_component_directory.py
@@ -120,7 +120,7 @@ class OpenComponentDirectoryAction(object):
             u'topic=ftrack.action.launch and '
             u'data.actionIdentifier="{0}" and '
             u'source.user.username="{1}" and '
-            u'data.host={2}'.format(
+            u'data.host="{2}"'.format(
                 self.identifier, self.session.api_user, platform.node()
             ),
             self.launch,

--- a/resource/hook/open_component_directory.py
+++ b/resource/hook/open_component_directory.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-
+import platform
 import ftrack_api
 import ftrack_connect.util
 
@@ -32,6 +32,7 @@ class OpenComponentDirectoryAction(object):
                     {
                         'label': 'Open directory',
                         'actionIdentifier': self.identifier,
+                        'host': platform.node()
                     }
                 ]
             }
@@ -107,15 +108,20 @@ class OpenComponentDirectoryAction(object):
     def register(self):
         '''Register to event hub.'''
         self.session.event_hub.subscribe(
-            u'topic=ftrack.action.discover '
-            u'and source.user.username="{0}"'.format(self.session.api_user),
+            u'topic=ftrack.action.discover and '
+            u'source.user.username="{0}" and '
+            u'data.host="{1}"'.format(
+                self.session.api_user, platform.node()
+            ),
             self.discover,
         )
 
         self.session.event_hub.subscribe(
-            'topic=ftrack.action.launch and data.actionIdentifier={0} and '
-            'source.user.username="{1}"'.format(
-                self.identifier, self.session.api_user
+            u'topic=ftrack.action.launch and '
+            u'data.actionIdentifier="{0}" and '
+            u'source.user.username="{1}" and '
+            u'data.host={2}'.format(
+                self.identifier, self.session.api_user, platform.node()
             ),
             self.launch,
         )


### PR DESCRIPTION
This patch is to ensure the open action target the orignal machine where the was registered.
Allowing to have the same user using connect on multiple machine.